### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/io.bit3.ThreemaQT.yml
+++ b/io.bit3.ThreemaQT.yml
@@ -15,7 +15,6 @@ finish-args:
 - "--device=dri"
 - "--env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess"
 - "--talk-name=org.kde.StatusNotifierWatcher"
-- "--own-name=org.kde.*"
 cleanup-commands:
 - /app/cleanup-BaseApp.sh
 modules:


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025